### PR TITLE
Modified how bot accesses new member username to make it have proper …

### DIFF
--- a/config/initializers/slack_api.rb
+++ b/config/initializers/slack_api.rb
@@ -4,12 +4,12 @@ Slack.configure do |config|
   config.token = ENV['slack_api_token']
 end
 
-#client = Slack.realtime
+client = Slack.realtime
 
-#client.on :team_join do |data|
-#  welcome = "Welcome to slashrocket, <@#{data['name']}>! Type `/rocket` for a quick tour of our channels. :simple_smile:"
-#  options = { channel: '#general', text: welcome, as_user: true }
-#  Slack.chat_postMessage(options)
-#end
+client.on :team_join do |data|
+  welcome = "Welcome to slashrocket, <@#{data['user']['name']}>! Type `/rocket` for a quick tour of our channels. :simple_smile:"
+  options = { channel: '#general', text: welcome, as_user: true }
+  Slack.chat_postMessage(options)
+end
 
-#client.start
+client.start


### PR DESCRIPTION
…output on team_join

I'm not sure why it makes it look like I changed a lot, just `data['name']` to `data['user']['name']` because the user value is a giant list of user details.
